### PR TITLE
Revert Reset Post Count on Focus. 

### DIFF
--- a/script.coffee
+++ b/script.coffee
@@ -4163,7 +4163,7 @@ Unread =
     @title = d.title
     $.on d, 'QRPostSuccessful', @post
     @update()
-    $.on window, 'scroll', Unread.scroll
+    $.on window, 'scroll focus', Unread.scroll
     Main.callbacks.push @node
 
   replies: []


### PR DESCRIPTION
Post Count now refreshes on focus. Any posts in the viewpoint of
the window will now be counted as "read" on focus.

Essentially, close #42
