### PR TITLE
Update for new 4chan post success page

### DIFF
--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -2861,7 +2861,7 @@
         if ((_ref = $('a', err)) != null) {
           _ref.target = '_blank';
         }
-      } else if (!(msg = $('b', doc))) {
+      } else if (!(msg = $('body', doc))) {
         err = 'Connection error with sys.4chan.org.';
       }
       if (err) {

--- a/script.coffee
+++ b/script.coffee
@@ -2272,7 +2272,7 @@ QR =
           "Reason: #{$('.reason', doc).innerHTML}"
     else if err = doc.getElementById 'errmsg' # error!
       $('a', err)?.target = '_blank' # duplicate image link
-    else unless msg = $ 'b', doc
+    else unless msg = $ 'body', doc
       err = 'Connection error with sys.4chan.org.'
 
     if err


### PR DESCRIPTION
4chan tweaked its 'post successful' screen, moving the comment that has the new post ID to be a child of the <body> element. This makes 4chan X interpret it correctly.
