### PR TITLE
CAPTCHA checking before posting

### DIFF
--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -415,23 +415,15 @@
       if (typeof GM_xmlhttpRequest !== 'undefined') {
         gmopts = {
           url: url,
+          data: opts.form,
           method: opts.form ? 'POST' : 'GET',
+          onload: callbacks.onload,
+          onabort: callbacks.onabort,
+          onerror: callbacks.onerror,
           headers: {
             Accept: 'text/html'
           }
         };
-        if (opts.form) {
-          gmopts.data = opts.form;
-        }
-        if (callbacks.onload) {
-          gmopts.onload = callbacks.onload;
-        }
-        if (callbacks.onabort) {
-          gmopts.onabort = callbacks.onabort;
-        }
-        if (callbacks.onerror) {
-          gmopts.onerror = callbacks.onerror;
-        }
         return GM_xmlhttpRequest(gmopts);
       } else {
         if (callbacks.onload) {

--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -2635,10 +2635,10 @@
             doc = d.implementation.createHTMLDocument('');
             doc.documentElement.innerHTML = data.responseText;
             if (ta = $('textarea', doc)) {
-              key = ta.innerHTML;
+              key = ta.textContent;
               QR.cleanError();
               return QR.captcha.addCaptcha(key, 'manual_challenge');
-            } else if ($.id('recaptcha_response_field', doc)) {
+            } else if ($('#recaptcha_response_field', doc)) {
               return QR.error('Bad CAPTCHA');
             } else {
               $.log('Could not understand response from CAPTCHA validator:', data.responseText);

--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -413,7 +413,6 @@
         opts = {};
       }
       if (typeof GM_xmlhttpRequest !== "undefined") {
-        console.log("Using GM_xmlhttpRequest");
         method = (_ref = opts.form) != null ? _ref : {
           "POST": "GET"
         };
@@ -438,7 +437,6 @@
         }
         return GM_xmlhttpRequest(gmopts);
       } else {
-        console.log("Using regular $.ajax");
         if (callbacks.onload) {
           newonload = function() {
             return callbacks.onload({
@@ -2649,20 +2647,17 @@
             doc.documentElement.innerHTML = data.responseText;
             if (ta = $('textarea', doc)) {
               key = ta.innerHTML;
-              console.log("Good CAPTCHA");
               QR.cleanError();
               return QR.captcha.addCaptcha(key, "manual_challenge");
             } else if ($('#recaptcha_response_field', doc)) {
-              console.log("Bad CAPTCHA");
               return QR.error("Bad CAPTCHA");
             } else {
-              console.error("Could not understand response from CAPTCHA validator:", data.responseText);
+              $.log("Could not understand response from CAPTCHA validator:", data.responseText);
               QR.error("Validation connection failed; adding CAPTCHA anyway");
               return QR.captcha.addCaptcha(challenge, response);
             }
           },
           onerror: function() {
-            console.error("CAPTCHA validation connection failed, adding CAPTCHA anyway");
             QR.error("Validation connection failed; adding CAPTCHA anyway");
             return QR.captcha.addCaptcha(challenge, response);
           }

--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -156,6 +156,7 @@
         'Quick Reply': [true, 'Reply without leaving the page'],
         'Focus on Alert': [true, 'Switch to tab if an error occurs'],
         'Cooldown': [true, 'Prevent "flood detected" errors'],
+        'Validate CAPTCHA': [true, 'Validate cached CAPTCHAs'],
         'Persistent QR': [false, 'The Quick reply won\'t disappear after posting'],
         'Auto Hide QR': [false, 'Automatically hide the quick reply when posting'],
         'Open Reply in New Tab': [false, 'Open replies in a new tab that are made from the main board'],
@@ -405,6 +406,52 @@
       }
       r.send(form);
       return r;
+    },
+    crossAjax: function(url, callbacks, opts) {
+      var gmopts, method, newonload, _ref;
+      if (opts == null) {
+        opts = {};
+      }
+      if (typeof GM_xmlhttpRequest !== "undefined") {
+        console.log("Using GM_xmlhttpRequest");
+        method = (_ref = opts.form) != null ? _ref : {
+          "POST": "GET"
+        };
+        gmopts = {
+          url: url,
+          method: opts.form ? "POST" : "GET",
+          headers: {
+            Accept: "text/html"
+          }
+        };
+        if (opts.form) {
+          gmopts.data = opts.form;
+        }
+        if (callbacks.onload) {
+          gmopts.onload = callbacks.onload;
+        }
+        if (callbacks.onabort) {
+          gmopts.onabort = callbacks.onabort;
+        }
+        if (callbacks.onerror) {
+          gmopts.onerror = callbacks.onerror;
+        }
+        return GM_xmlhttpRequest(gmopts);
+      } else {
+        console.log("Using regular $.ajax");
+        if (callbacks.onload) {
+          newonload = function() {
+            return callbacks.onload({
+              readyState: this.readyState,
+              responseText: this.responseText,
+              status: this.status,
+              statusText: this.statusText
+            });
+          };
+          callbacks.onload = newonload;
+        }
+        return $.ajax(url, callbacks, opts);
+      }
     },
     cache: function(url, cb) {
       var req;
@@ -2573,22 +2620,63 @@
         this.count($.get('captchas', []).length);
         return this.reload();
       },
-      save: function() {
-        var captcha, captchas, response;
-        if (!(response = this.input.value)) {
-          return;
-        }
+      addCaptcha: function(challenge, response) {
+        var captcha, captchas;
         captchas = $.get('captchas', []);
         while ((captcha = captchas[0]) && captcha.time < Date.now()) {
           captchas.shift();
         }
         captchas.push({
-          challenge: this.challenge.firstChild.value,
+          challenge: challenge,
           response: response,
           time: this.timeout
         });
         $.set('captchas', captchas);
-        this.count(captchas.length);
+        return this.count(captchas.length);
+      },
+      validateCaptcha: function(challenge, response) {
+        var callbacks, opts;
+        opts = {
+          form: $.formData({
+            recaptcha_challenge_field: challenge,
+            recaptcha_response_field: response
+          })
+        };
+        callbacks = {
+          onload: function(data) {
+            var doc, key, ta;
+            doc = d.implementation.createHTMLDocument('');
+            doc.documentElement.innerHTML = data.responseText;
+            if (ta = $('textarea', doc)) {
+              key = ta.innerHTML;
+              console.log("Good CAPTCHA");
+              QR.cleanError();
+              return QR.captcha.addCaptcha(key, "manual_challenge");
+            } else if ($('#recaptcha_response_field', doc)) {
+              console.log("Bad CAPTCHA");
+              return QR.error("Bad CAPTCHA");
+            } else {
+              return console.error("Could not understand response from CAPTCHA validator:", data.responseText);
+            }
+          },
+          onerror: function() {
+            console.error("CAPTCHA validation connection failed, adding CAPTCHA anyway");
+            return QR.captcha.addCaptcha(challenge, response);
+          }
+        };
+        return $.crossAjax("//www.google.com/recaptcha/api/noscript?k=6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc", callbacks, opts);
+      },
+      save: function() {
+        var challenge, response;
+        if (!(response = this.input.value)) {
+          return;
+        }
+        challenge = this.challenge.firstChild.value;
+        if (Conf['Validate CAPTCHA']) {
+          this.validateCaptcha(challenge, response);
+        } else {
+          this.addCaptcha(challenge, response);
+        }
         return this.reload();
       },
       load: function() {

--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -2656,11 +2656,14 @@
               console.log("Bad CAPTCHA");
               return QR.error("Bad CAPTCHA");
             } else {
-              return console.error("Could not understand response from CAPTCHA validator:", data.responseText);
+              console.error("Could not understand response from CAPTCHA validator:", data.responseText);
+              QR.error("Validation connection failed; adding CAPTCHA anyway");
+              return QR.captcha.addCaptcha(challenge, response);
             }
           },
           onerror: function() {
             console.error("CAPTCHA validation connection failed, adding CAPTCHA anyway");
+            QR.error("Validation connection failed; adding CAPTCHA anyway");
             return QR.captcha.addCaptcha(challenge, response);
           }
         };

--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -2862,7 +2862,7 @@
           err = 'No valid captcha.';
         } else {
           response = response.trim();
-          if (!/\s/.test(response)) {
+          if (!/\s|_/.test(response)) {
             response = "" + response + " " + response;
           }
         }

--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -408,19 +408,16 @@
       return r;
     },
     crossAjax: function(url, callbacks, opts) {
-      var gmopts, method, newonload, _ref;
+      var gmopts, newonload;
       if (opts == null) {
         opts = {};
       }
-      if (typeof GM_xmlhttpRequest !== "undefined") {
-        method = (_ref = opts.form) != null ? _ref : {
-          "POST": "GET"
-        };
+      if (typeof GM_xmlhttpRequest !== 'undefined') {
         gmopts = {
           url: url,
-          method: opts.form ? "POST" : "GET",
+          method: opts.form ? 'POST' : 'GET',
           headers: {
-            Accept: "text/html"
+            Accept: 'text/html'
           }
         };
         if (opts.form) {
@@ -2648,21 +2645,21 @@
             if (ta = $('textarea', doc)) {
               key = ta.innerHTML;
               QR.cleanError();
-              return QR.captcha.addCaptcha(key, "manual_challenge");
-            } else if ($('#recaptcha_response_field', doc)) {
-              return QR.error("Bad CAPTCHA");
+              return QR.captcha.addCaptcha(key, 'manual_challenge');
+            } else if ($.id('recaptcha_response_field', doc)) {
+              return QR.error('Bad CAPTCHA');
             } else {
-              $.log("Could not understand response from CAPTCHA validator:", data.responseText);
-              QR.error("Validation connection failed; adding CAPTCHA anyway");
+              $.log('Could not understand response from CAPTCHA validator:', data.responseText);
+              QR.error('Validation connection failed; adding CAPTCHA anyway');
               return QR.captcha.addCaptcha(challenge, response);
             }
           },
           onerror: function() {
-            QR.error("Validation connection failed; adding CAPTCHA anyway");
+            QR.error('Validation connection failed; adding CAPTCHA anyway');
             return QR.captcha.addCaptcha(challenge, response);
           }
         };
-        return $.crossAjax("//www.google.com/recaptcha/api/noscript?k=6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc", callbacks, opts);
+        return $.crossAjax('//www.google.com/recaptcha/api/noscript?k=6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc', callbacks, opts);
       },
       save: function() {
         var challenge, response;

--- a/script.coffee
+++ b/script.coffee
@@ -338,13 +338,12 @@ $.extend $,
     r.send form
     r
   crossAjax: (url, callbacks, opts={}) ->
-    if typeof GM_xmlhttpRequest != "undefined"
-      method = opts.form ? "POST" : "GET"
+    if typeof GM_xmlhttpRequest != 'undefined'
       gmopts =
         url: url
-        method: if opts.form then "POST" else "GET"
+        method: if opts.form then 'POST' else 'GET'
         headers:
-          Accept: "text/html"
+          Accept: 'text/html'
       if opts.form
         gmopts.data = opts.form
       if callbacks.onload
@@ -2070,17 +2069,17 @@ QR =
           if ta = $ 'textarea', doc
             key = ta.innerHTML
             QR.cleanError()
-            QR.captcha.addCaptcha key, "manual_challenge"
-          else if $ '#recaptcha_response_field', doc
-            QR.error "Bad CAPTCHA"
+            QR.captcha.addCaptcha key, 'manual_challenge'
+          else if $.id 'recaptcha_response_field', doc
+            QR.error 'Bad CAPTCHA'
           else
-            $.log "Could not understand response from CAPTCHA validator:", data.responseText
-            QR.error "Validation connection failed; adding CAPTCHA anyway"
+            $.log 'Could not understand response from CAPTCHA validator:', data.responseText
+            QR.error 'Validation connection failed; adding CAPTCHA anyway'
             QR.captcha.addCaptcha challenge, response
         onerror: ->
-          QR.error "Validation connection failed; adding CAPTCHA anyway"
+          QR.error 'Validation connection failed; adding CAPTCHA anyway'
           QR.captcha.addCaptcha challenge, response
-      $.crossAjax "//www.google.com/recaptcha/api/noscript?k=6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc", callbacks, opts
+      $.crossAjax '//www.google.com/recaptcha/api/noscript?k=6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc', callbacks, opts
     save: ->
       return unless response = @input.value
       challenge = @challenge.firstChild.value

--- a/script.coffee
+++ b/script.coffee
@@ -2079,8 +2079,11 @@ QR =
             QR.error "Bad CAPTCHA"
           else
             console.error "Could not understand response from CAPTCHA validator:", data.responseText
+            QR.error "Validation connection failed; adding CAPTCHA anyway"
+            QR.captcha.addCaptcha challenge, response
         onerror: ->
           console.error "CAPTCHA validation connection failed, adding CAPTCHA anyway"
+          QR.error "Validation connection failed; adding CAPTCHA anyway"
           QR.captcha.addCaptcha challenge, response
       $.crossAjax "//www.google.com/recaptcha/api/noscript?k=6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc", callbacks, opts
     save: ->

--- a/script.coffee
+++ b/script.coffee
@@ -340,27 +340,23 @@ $.extend $,
   crossAjax: (url, callbacks, opts={}) ->
     if typeof GM_xmlhttpRequest != 'undefined'
       gmopts =
-        url: url
-        method: if opts.form then 'POST' else 'GET'
+        url:     url
+        data:    opts.form
+        method:  if opts.form then 'POST' else 'GET'
+        onload:  callbacks.onload
+        onabort: callbacks.onabort
+        onerror: callbacks.onerror
         headers:
           Accept: 'text/html'
-      if opts.form
-        gmopts.data = opts.form
-      if callbacks.onload
-        gmopts.onload = callbacks.onload
-      if callbacks.onabort
-        gmopts.onabort = callbacks.onabort
-      if callbacks.onerror
-        gmopts.onerror = callbacks.onerror
       GM_xmlhttpRequest gmopts
     else
       if callbacks.onload
         newonload = ->
           callbacks.onload
-            readyState: @readyState
+            readyState:   @readyState
             responseText: @responseText
-            status: @status
-            statusText: @statusText
+            status:       @status
+            statusText:   @statusText
         callbacks.onload = newonload
       $.ajax url, callbacks, opts
   cache: (url, cb) ->

--- a/script.coffee
+++ b/script.coffee
@@ -2257,7 +2257,7 @@ QR =
         response = response.trim()
         # one-word-captcha:
         # If there's only one word, duplicate it.
-        response = "#{response} #{response}" unless /\s/.test response
+        response = "#{response} #{response}" unless /\s|_/.test response
 
     if err
       # stop auto-posting

--- a/script.coffee
+++ b/script.coffee
@@ -2063,10 +2063,10 @@ QR =
           doc = d.implementation.createHTMLDocument ''
           doc.documentElement.innerHTML = data.responseText
           if ta = $ 'textarea', doc
-            key = ta.innerHTML
+            key = ta.textContent
             QR.cleanError()
             QR.captcha.addCaptcha key, 'manual_challenge'
-          else if $.id 'recaptcha_response_field', doc
+          else if $ '#recaptcha_response_field', doc
             QR.error 'Bad CAPTCHA'
           else
             $.log 'Could not understand response from CAPTCHA validator:', data.responseText

--- a/script.coffee
+++ b/script.coffee
@@ -339,7 +339,6 @@ $.extend $,
     r
   crossAjax: (url, callbacks, opts={}) ->
     if typeof GM_xmlhttpRequest != "undefined"
-      console.log "Using GM_xmlhttpRequest"
       method = opts.form ? "POST" : "GET"
       gmopts =
         url: url
@@ -356,7 +355,6 @@ $.extend $,
         gmopts.onerror = callbacks.onerror
       GM_xmlhttpRequest gmopts
     else
-      console.log "Using regular $.ajax"
       if callbacks.onload
         newonload = ->
           callbacks.onload
@@ -2071,18 +2069,15 @@ QR =
           doc.documentElement.innerHTML = data.responseText
           if ta = $ 'textarea', doc
             key = ta.innerHTML
-            console.log "Good CAPTCHA"
             QR.cleanError()
             QR.captcha.addCaptcha key, "manual_challenge"
           else if $ '#recaptcha_response_field', doc
-            console.log "Bad CAPTCHA"
             QR.error "Bad CAPTCHA"
           else
-            console.error "Could not understand response from CAPTCHA validator:", data.responseText
+            $.log "Could not understand response from CAPTCHA validator:", data.responseText
             QR.error "Validation connection failed; adding CAPTCHA anyway"
             QR.captcha.addCaptcha challenge, response
         onerror: ->
-          console.error "CAPTCHA validation connection failed, adding CAPTCHA anyway"
           QR.error "Validation connection failed; adding CAPTCHA anyway"
           QR.captcha.addCaptcha challenge, response
       $.crossAjax "//www.google.com/recaptcha/api/noscript?k=6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc", callbacks, opts


### PR DESCRIPTION
This change makes it so when you cache a CAPTCHA with shift+enter, the CAPTCHA is validated before being cached. This solves the issue where you make a post, wait a while for it and maybe an image to upload, just to get told the CAPTCHA was bad and you have to do the upload again.

This behavior is optional and controlled by the new "Validate CAPTCHA" option, which defaults to on. If there are any connection errors in checking the CAPTCHA, then the CAPTCHA is cached anyway.

Uncached CAPTCHAs aren't checked, partly because it would be more difficult (the ajax check would have to happen in the submit handler, and queue the rest of the submission to happen later) and because if the connection to google's recaptcha server is slow for the user, the validation will slow down posting for the user.

It works by using the recaptcha's noscript fallback. If you don't have javascript turned on, then 4chan shows an iframe to a recaptcha page with a captcha, and when you solve it, it gives you a new challenge code to copy and paste into a field on the 4chan posting form. This allows the captcha validation to be decoupled from the actual posting.

Google's recaptcha server is a different domain from 4chan, so the ajax call to it is cross-domain, but it doesn't set its headers to explicitly allow that. Chrome allows userscripts to do cross-domain ajax calls by default. For Firefox Greasemonkey/Scriptish users, GM_xmlhttpRequest is used. I made a function $.crossAjax which acts as a wrapper for both of these. I haven't tested it in Opera.
