### PR TITLE
Clear text box and image immediately on CAPTCHA reload

### DIFF
--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -2592,12 +2592,16 @@
         return this.reload();
       },
       load: function() {
-        var challenge;
+        var challenge,
+          _this = this;
         this.timeout = Date.now() + 4 * $.MINUTE;
         challenge = this.challenge.firstChild.value;
         this.img.alt = challenge;
         this.img.src = "//www.google.com/recaptcha/api/image?c=" + challenge;
-        return this.input.value = null;
+        return this.img.onload = function() {
+          _this.img.style.visibility = 'visible';
+          return _this.input.value = null;
+        };
       },
       count: function(count) {
         this.input.placeholder = (function() {
@@ -2613,6 +2617,8 @@
         return this.input.alt = count;
       },
       reload: function(focus) {
+        QR.captcha.input.value = null;
+        QR.captcha.img.style.visibility = 'hidden';
         $.globalEval('javascript:Recaptcha.reload("t")');
         if (focus) {
           return QR.captcha.input.focus();

--- a/script.coffee
+++ b/script.coffee
@@ -2039,7 +2039,9 @@ QR =
       challenge = @challenge.firstChild.value
       @img.alt  = challenge
       @img.src  = "//www.google.com/recaptcha/api/image?c=#{challenge}"
-      @input.value = null
+      @img.onload = =>
+        @img.style.visibility = 'visible'
+        @input.value = null
     count: (count) ->
       @input.placeholder = switch count
         when 0
@@ -2050,6 +2052,8 @@ QR =
           "Verification (#{count} cached captchas)"
       @input.alt = count # For XTRM RICE.
     reload: (focus) ->
+      QR.captcha.input.value = null
+      QR.captcha.img.style.visibility = 'hidden'
       # the "t" argument prevents the input from being focused
       $.globalEval 'javascript:Recaptcha.reload("t")'
       # Focus if we meant to.


### PR DESCRIPTION
When the CAPTCHA is triggered to be reloaded, the text field immediately clears and the current image is hidden. Previously, it would wait until the Recaptcha code finished processing the reload, which involves network traffic and some (occasionally very) noticeable lag. A user entering in many CAPTCHAs in a row to the cache will feel a more responsible UI; before, sometimes I would wonder if I pushed shift+enter hard enough and get ready to push it again as my CAPTCHA lingered there for a moment.

(This should be easily merge-able with my other pull request.)
