### PR TITLE
This might also be a good idea.

### DIFF
--- a/src/Miscellaneous/FileInfo.coffee
+++ b/src/Miscellaneous/FileInfo.coffee
@@ -9,11 +9,11 @@ FileInfo =
     return if !@file or @isClone
     @file.text.innerHTML = "<span class=file-info>#{FileInfo.format Conf['fileInfo'], @}</span>"
   format: (formatString, post) ->
-    formatString.replace /%([A-Za-z])/g, (s, c) ->
+    formatString.replace /%([A-Za-z])|[^%]+/g, (s, c) ->
       if c of FileInfo.formatters
         FileInfo.formatters[c].call(post)
       else
-        s
+        FileInfo.escape s
   convertUnit: (size, unit) ->
     if unit is 'B'
       return "#{size.toFixed()} Bytes"


### PR DESCRIPTION
This kills a possible attack (only possible in Chrom\* after #341) where if a malicious script is executed on the page once, it can change 4chan X's settings so that it is executed every time the page loads.  This is more of a judgement call whether to include because it kills what could be thought of as a feature (user HTML in the file info).  Although I doubt many people are using this.
